### PR TITLE
Feature adoption form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log*
 
 .lesson.yml
 node-group-project.md
+public/bundle.js

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,9 +1,21 @@
 DROP TABLE IF EXISTS creature_types;
 CREATE TABLE creature_types (
-    id SERIAL PRIMARY KEY,
-    type VARCHAR(255) NOT NULL, 
-    description TEXT,
-    img_url VARCHAR(255)
+  id SERIAL PRIMARY KEY,
+  type VARCHAR(255) NOT NULL,
+  description TEXT,
+  img_url VARCHAR(255)
 );
-
 CREATE UNIQUE INDEX index ON creature_types(type);
+
+DROP TABLE IF EXISTS adoption_applications;
+CREATE TABLE adoption_applications (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  phone_number VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  home_status VARCHAR(255) NOT NULL,
+  application_status VARCHAR(255),
+  creature_id INTEGER NOT NULL
+);
+-- NEED TO UPDATE THE creature_id to only accept the foreign key once that table schema is created
+-- creature_id INTEGER REFERENCES name_of_db(id)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -27,7 +27,5 @@ CREATE TABLE adoption_applications (
   email VARCHAR(255) NOT NULL,
   home_status VARCHAR(255) NOT NULL,
   application_status VARCHAR(255),
-  creature_id INTEGER NOT NULL
+  creature_id INTEGER REFERENCES adoptable_creatures(id) NOT NULL
 );
--- NEED TO UPDATE THE creature_id to only accept the foreign key once that table schema is created
--- creature_id INTEGER REFERENCES name_of_db(id)

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,5 +1,43 @@
 INSERT INTO creature_types(type, description, img_url)
-VALUES 
-    ('Nyan Cat', 'A mystical flying space feline in the shape of a pop tart.', 'https://upload.wikimedia.org/wikipedia/en/e/ed/Nyan_cat_250px_frame.PNG'),
-    ('Dragon', 'A reptile in varired sizes and magical abilities.', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Dragon.svg/1200px-Dragon.svg.png'),
-    ('Unicorn', 'A equine animal, typically with white fur, easily identifed by a large horn on their heads', 'https://upload.wikimedia.org/wikipedia/en/7/78/The_Hunt_of_the_Unicorn_Tapestry_7.jpg');
+VALUES
+  (
+    'Nyan Cat',
+    'A mystical flying space feline in the shape of a pop tart.',
+    'https://upload.wikimedia.org/wikipedia/en/e/ed/Nyan_cat_250px_frame.PNG'
+  ),
+  (
+    'Dragon',
+    'A reptile in varired sizes and magical abilities.',
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Dragon.svg/1200px-Dragon.svg.png'
+  ),
+  (
+    'Unicorn',
+    'A equine animal, typically with white fur, easily identifed by a large horn on their heads.',
+    'https://upload.wikimedia.org/wikipedia/en/7/78/The_Hunt_of_the_Unicorn_Tapestry_7.jpg'
+  );
+
+INSERT INTO adoption_applications(
+    name,
+    phone_number,
+    email,
+    home_status,
+    application_status,
+    creature_id
+  )
+VALUES
+  (
+    'Bob',
+    '617-666-8888',
+    'bobs@burgers.com',
+    'own',
+    'pending',
+    1
+  ),
+  (
+    'A Person',
+    '617-666-8901',
+    'a@person.com',
+    'rent',
+    'pending',
+    1
+  )

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -53,7 +53,7 @@ VALUES
     'can be adopted',
     2
   );
-  
+
 INSERT INTO adoption_applications(
     name,
     phone_number,
@@ -78,4 +78,4 @@ VALUES
     'rent',
     'pending',
     1
-  )
+  );

--- a/server/server.js
+++ b/server/server.js
@@ -1,50 +1,53 @@
-const express = require("express")
-const path = require("path")
-const logger = require("morgan")
-const bodyParser = require("body-parser")
-const hbsMiddleware = require("express-handlebars")
-const fs = require("fs")
-const _ = require("lodash")
-const createError = require("http-errors")
+const express = require("express");
+const path = require("path");
+const logger = require("morgan");
+const bodyParser = require("body-parser");
+const hbsMiddleware = require("express-handlebars");
+const fs = require("fs");
+const _ = require("lodash");
+const createError = require("http-errors");
 
-const app = express()
+const app = express();
 
-app.set("views", path.join(__dirname, "../views"))
+app.set("views", path.join(__dirname, "../views"));
 app.engine(
   "hbs",
   hbsMiddleware({
     defaultLayout: "default",
     extname: ".hbs"
   })
-)
+);
 
-app.set("view engine", "hbs")
+app.set("view engine", "hbs");
 
-app.use(logger("dev"))
-app.use(express.json())
+app.use(logger("dev"));
+app.use(express.json());
 
-app.use(express.static(path.join(__dirname, "../public")))
-app.use(bodyParser.urlencoded({ extended: true }))
-app.use(bodyParser.json())
+app.use(express.static(path.join(__dirname, "../public")));
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
 
-const { Pool } = require("pg")
+const { Pool } = require("pg");
 
 const pool = new Pool({
   connectionString: "postgres://postgres:password@127.0.0.1:5432/fluff_flame"
-})
+});
 
 // API Endpoints
 app.get("/api/v1/creature_types", (req, res) => {
-  pool.connect().then(client => {
-    client.query("SELECT * FROM creature_types").then(result => {
-      const creatures = result.rows;
-      client.release();
-      res.json(creatures);
+  pool
+    .connect()
+    .then(client => {
+      client.query("SELECT * FROM creature_types").then(result => {
+        const creatures = result.rows;
+        client.release();
+        res.json(creatures);
+      });
+    })
+    .catch(error => {
+      console.log("ERROR =====> ", error);
     });
-  }).catch(error => {
-    console.log("ERROR =====> ", error);
-  });
-})
+});
 
 app.get("/api/v1/creature_types/:type", (req, res) => {
   const findType = req.params.type;
@@ -68,17 +71,34 @@ app.get("/api/v1/creature_types/:type", (req, res) => {
     });
 });
 
+app.post("/api/v1/applicants", (req, res) => {
+  const { name, phone_number, email, home_status } = req.body;
+
+  const getCreatureID = 1; // waiting for component to be created for further edits ============
+  console.log([name, phone_number, email, home_status, "pending", getCreatureID])
+
+  pool
+    .query(
+      "INSERT INTO adoption_applications (name, phone_number, email, home_status, application_status, creature_id) VALUES ($1, $2, $3, $4, $5, $6)",
+      [name, phone_number, email, home_status, "pending", getCreatureID]
+    )
+    .catch(err => {
+      console.log(err);
+      res.sendStatus(500);
+    });
+});
+
 // Express routes
 app.get("/", (req, res) => {
   res.redirect("/creatures");
 });
 
-app.get('*', (req, res) => {
-  res.render("home")
-})
+app.get("*", (req, res) => {
+  res.render("home");
+});
 
 app.listen(3000, "0.0.0.0", () => {
-  console.log("Server is listening...")
-})
+  console.log("Server is listening...");
+});
 
-module.exports = app
+module.exports = app;

--- a/src/components/AdoptionForm.js
+++ b/src/components/AdoptionForm.js
@@ -4,7 +4,7 @@ import validateForm from "../functions/validateForm";
 import postData from "../functions/postData";
 
 const AdoptionForm = props => {
-  const POST_API_PATH = "/api/v1/applicants";
+  const postAPIpath = "/api/v1/applicants";
   const defaultApplicant = {
     name: "",
     phoneNumber: "",
@@ -17,13 +17,13 @@ const AdoptionForm = props => {
 
   const clearForm = () => setNewApplicant(defaultApplicant);
 
-  const handleChange = e => {
-    const { name, value } = e.currentTarget;
+  const handleChange = event => {
+    const { name, value } = event.currentTarget;
     setNewApplicant({ ...newApplicant, [name]: value });
   };
 
-  const submitApplicant = e => {
-    e.preventDefault();
+  const submitApplicant = event => {
+    event.preventDefault();
     if (
       validateForm(
         ["name", "phoneNumber", "email", "homeStatus"],
@@ -37,7 +37,7 @@ const AdoptionForm = props => {
         email: newApplicant.email,
         home_status: newApplicant.homeStatus
       };
-      postData(POST_API_PATH, payload);
+      postData(postAPIpath, payload);
       clearForm();
       props.submitState(true)
       props.showForm(false)

--- a/src/components/AdoptionForm.js
+++ b/src/components/AdoptionForm.js
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import ErrorList from "./ErrorList";
+import validateForm from "../functions/validateForm";
+
+const AdoptionForm = props => {
+  const defaultApplicant = {
+    name: "",
+    phoneNumber: "",
+    email: "",
+    homeStatus: ""
+  };
+  const [newApplicant, setNewApplicant] = useState(defaultApplicant);
+  const [errors, setErrors] = useState({});
+
+  const handleChange = e => {
+    const { name, value } = e.currentTarget;
+    setNewApplicant({ ...newApplicant, [name]: value });
+  };
+
+  const clearForm = e => {
+    e.preventDefault();
+    setNewApplicant(defaultApplicant);
+  };
+
+  const submitApplicant = e => {
+    e.preventDefault();
+    if (
+      validateForm(
+        ["name", "phoneNumber", "email", "homeStatus"],
+        newApplicant,
+        setErrors
+      )
+    ) {
+      console.log(newApplicant); // ================== awaiting db to post to
+    }
+  };
+
+  return (
+    <form className="callout" onSubmit={submitApplicant}>
+      <ErrorList errors={errors} />
+      <label>
+        Applicant Name*:
+        <input
+          name="name"
+          id="adoptionForm-name"
+          type="text"
+          value={newApplicant.name}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Phone Number*:
+        <input
+          name="phoneNumber"
+          id="adoptionForm-phoneNumber"
+          type="text"
+          value={newApplicant.phoneNumber}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Email Address*:
+        <input
+          name="email"
+          id="adoptionForm-email"
+          type="text"
+          value={newApplicant.email}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Home Status*:
+        <select
+          name="homeStatus"
+          id="adoptionForm-homeStatus"
+          value={newApplicant.homeStatus}
+          onChange={handleChange}
+        >
+          <option type="text" value="">
+            -
+          </option>
+          <option type="text" value="rent">
+            Rent
+          </option>
+          <option type="text" value="own">
+            Own
+          </option>
+        </select>
+      </label>
+      <div className="button-group">
+        <input className="button" type="submit" value="Submit" />
+        <button className="button" type="button" onClick={clearForm}>
+          Clear
+        </button>
+      </div>
+      <div>* denotes required.</div>
+    </form>
+  );
+};
+
+export default AdoptionForm;

--- a/src/components/AdoptionForm.js
+++ b/src/components/AdoptionForm.js
@@ -1,25 +1,25 @@
 import React, { useState } from "react";
 import ErrorList from "./ErrorList";
 import validateForm from "../functions/validateForm";
+import postData from "../functions/postData";
 
 const AdoptionForm = props => {
+  const POST_API_PATH = "/api/v1/applicants";
   const defaultApplicant = {
     name: "",
     phoneNumber: "",
     email: "",
     homeStatus: ""
   };
+
   const [newApplicant, setNewApplicant] = useState(defaultApplicant);
   const [errors, setErrors] = useState({});
+
+  const clearForm = () => setNewApplicant(defaultApplicant);
 
   const handleChange = e => {
     const { name, value } = e.currentTarget;
     setNewApplicant({ ...newApplicant, [name]: value });
-  };
-
-  const clearForm = e => {
-    e.preventDefault();
-    setNewApplicant(defaultApplicant);
   };
 
   const submitApplicant = e => {
@@ -31,7 +31,16 @@ const AdoptionForm = props => {
         setErrors
       )
     ) {
-      console.log(newApplicant); // ================== awaiting db to post to
+      const payload = {
+        name: newApplicant.name,
+        phone_number: newApplicant.phoneNumber,
+        email: newApplicant.email,
+        home_status: newApplicant.homeStatus
+      };
+      postData(POST_API_PATH, payload);
+      clearForm();
+      props.submitState(true)
+      props.showForm(false)
     }
   };
 
@@ -74,26 +83,17 @@ const AdoptionForm = props => {
           name="homeStatus"
           id="adoptionForm-homeStatus"
           value={newApplicant.homeStatus}
-          onChange={handleChange}
-        >
-          <option type="text" value="">
-            -
-          </option>
-          <option type="text" value="rent">
-            Rent
-          </option>
-          <option type="text" value="own">
-            Own
-          </option>
+          onChange={handleChange}>
+          <option type="text" value="">-</option>
+          <option type="text" value="rent">Rent</option>
+          <option type="text" value="own">Own</option>
         </select>
       </label>
       <div className="button-group">
         <input className="button" type="submit" value="Submit" />
-        <button className="button" type="button" onClick={clearForm}>
-          Clear
-        </button>
+        <button className="button" type="button" onClick={clearForm}>Clear</button>
       </div>
-      <div>* denotes required.</div>
+      <div>* All feilds required.</div>
     </form>
   );
 };

--- a/src/components/AdoptionFormButton.js
+++ b/src/components/AdoptionFormButton.js
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import AdoptionForm from "./AdoptionForm";
+
+const AdoptionFormButton = props => {
+  const [toggleForm, setToggleForm] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const clickForm = () => setToggleForm(!toggleForm);
+
+  const formProcess = () => {
+    if (isSubmitted) {
+      return "Thank you for submitting! Your request is in process.";
+    } else if (toggleForm) {
+      return "Close Form";
+    } else {
+      return "Adopt me!";
+    }
+  };
+
+  return (
+    <div>
+      <button className="button" onClick={clickForm} disabled={isSubmitted}>
+        {formProcess()}
+      </button>
+      {toggleForm && (
+        <AdoptionForm submitState={setIsSubmitted} showForm={setToggleForm} />
+      )}
+    </div>
+  );
+};
+
+export default AdoptionFormButton;

--- a/src/components/ErrorList.js
+++ b/src/components/ErrorList.js
@@ -1,0 +1,23 @@
+import React from "react";
+import _ from "lodash";
+
+const ErrorList = props => {
+  const errantFields = Object.keys(props.errors);
+  if (errantFields.length > 0) {
+    const listItems = errantFields.map((field, i) => (
+      <li key={i}>
+        {_.capitalize(field)} {props.errors[field]}{" "}
+      </li>
+    ));
+
+    return (
+      <div className="callout alert">
+        <ul>{listItems}</ul>
+      </div>
+    );
+  } else {
+    return "";
+  }
+};
+
+export default ErrorList;

--- a/src/containers/IndexTypes.js
+++ b/src/containers/IndexTypes.js
@@ -1,8 +1,6 @@
 import React, { Fragment, useState, useEffect } from "react";
-
 import fetchData from "../functions/fetchData";
 import CardType from "../components/CardType";
-import AdoptionForm from "../components/AdoptionForm"; /// TESTING ONLY ====================
 
 const IndexTypes = props => {
   const [creatureTypes, setCreatureTypes] = useState([]);
@@ -24,9 +22,6 @@ const IndexTypes = props => {
 
   return (
     <Fragment>
-      <AdoptionForm
-      // FOR TESTING ONLY remove component after =======================================
-      />
       <h1>The Order of Fluff and Flame Adoption Agency</h1>
       <h2>Select a Creature to adopt!</h2>
       {mapTypes}

--- a/src/containers/IndexTypes.js
+++ b/src/containers/IndexTypes.js
@@ -5,8 +5,8 @@ import CardType from "../components/CardType";
 const IndexTypes = props => {
   const [creatureTypes, setCreatureTypes] = useState([]);
 
-  const API_ENDPOINT = "/api/v1/creature_types";
-  const fetchCreatureTypes = () => fetchData(API_ENDPOINT, setCreatureTypes);
+  const apiEndpoint = "/api/v1/creature_types";
+  const fetchCreatureTypes = () => fetchData(apiEndpoint, setCreatureTypes);
   useEffect(fetchCreatureTypes, []);
 
   console.log(creatureTypes);

--- a/src/containers/IndexTypes.js
+++ b/src/containers/IndexTypes.js
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from "react";
 
 import fetchData from "../functions/fetchData";
 import CardType from "../components/CardType";
+import AdoptionForm from "../components/AdoptionForm"; /// TESTING ONLY ====================
 
 const IndexTypes = props => {
   const [creatureTypes, setCreatureTypes] = useState([]);
@@ -23,6 +24,9 @@ const IndexTypes = props => {
 
   return (
     <Fragment>
+      <AdoptionForm
+      // FOR TESTING ONLY remove component after =======================================
+      />
       <h1>The Order of Fluff and Flame Adoption Agency</h1>
       <h2>Select a Creature to adopt!</h2>
       {mapTypes}

--- a/src/functions/postData.js
+++ b/src/functions/postData.js
@@ -1,0 +1,20 @@
+const postData = (apiPath, payload) => {
+  fetch(apiPath, {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: { "Content-Type": "application/json" }
+  })
+    .then(response => {
+      if (response.ok) {
+        return response;
+      } else {
+        let errorMessage = `${response.status} (${response.statusText})`,
+          error = new Error(errorMessage);
+        throw error;
+      }
+    })
+    .then(response => response.json())
+    .catch(error => console.error(`Error in fetch: ${error.message}`));
+};
+
+export default postData;

--- a/src/functions/validateForm.js
+++ b/src/functions/validateForm.js
@@ -1,8 +1,6 @@
 /* ===============================
 
 POJO to take parameters to set the required fields.
-  stateGetter is name of the state to update.
-  errorSetter is name of the setter for the error state.
 Will also need states in to hold errors states for validation messages.
   const [errors, setErrors] = useState({});
 Will need to add <ErrorList errors={error state name} /> to display errors

--- a/src/functions/validateForm.js
+++ b/src/functions/validateForm.js
@@ -1,26 +1,58 @@
-// POJO to take parameters to set the required fields,
-// stateGetter is name of the state to update,
-// errorSetter is name of the setter for the error state
-// will need states in to catch errors for the validation below
-//     const [errors, setErrors] = useState({});
-// will need to add <ErrorList errors={error state name} /> to display errors
+/* ===============================
+
+POJO to take parameters to set the required fields.
+  stateGetter is name of the state to update.
+  errorSetter is name of the setter for the error state.
+Will also need states in to hold errors states for validation messages.
+  const [errors, setErrors] = useState({});
+Will need to add <ErrorList errors={error state name} /> to display errors
+
+Can validate phoneNumbers and email for format, but must use the camelCase 
+version specifically to work, otherwise will error ie must use camelCase 
+in form values name="phoneNumbers" and as obj key names.
+
+=============================== */
 
 const validateForm = (requiredFields, stateGetter, errorSetter) => {
-    let submitErrors = {};
-    requiredFields.forEach(field => {
-      if (stateGetter[field].trim() === "") {
-        submitErrors = {
-          ...submitErrors,
-          [field]: "is required."
-        };
-      }
-    });
-    errorSetter(submitErrors);
-    return (
-      Object.entries(submitErrors).length === 0 &&
-      submitErrors.constructor === Object
-    );
-  };
-  
-  export default validateForm;
-  
+  let submitErrors = {};
+  requiredFields.forEach(field => {
+    if (stateGetter[field].trim() === "") {
+      submitErrors = {
+        ...submitErrors,
+        [field]: "is required."
+      };
+    }
+  });
+
+  const validPhoneNo = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+  if (
+    !validPhoneNo.test(stateGetter["phoneNumber"]) &&
+    stateGetter["phoneNumber"].trim() !== ""
+  ) {
+    submitErrors = {
+      ...submitErrors,
+      ["phoneNumber"]:
+        "must be in valid format: xxx-xxx-xxxx, xxx.xxx.xxxx, xxx xxx xxxx"
+    };
+    console.log("is correct");
+  }
+
+  const validEmail = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+  if (
+    !validEmail.test(stateGetter["email"]) &&
+    stateGetter["email"].trim() !== ""
+  ) {
+    submitErrors = {
+      ...submitErrors,
+      ["email"]: "must be in valid format."
+    };
+  }
+
+  errorSetter(submitErrors);
+  return (
+    Object.entries(submitErrors).length === 0 &&
+    submitErrors.constructor === Object
+  );
+};
+
+export default validateForm;

--- a/src/functions/validateForm.js
+++ b/src/functions/validateForm.js
@@ -1,0 +1,26 @@
+// POJO to take parameters to set the required fields,
+// stateGetter is name of the state to update,
+// errorSetter is name of the setter for the error state
+// will need states in to catch errors for the validation below
+//     const [errors, setErrors] = useState({});
+// will need to add <ErrorList errors={error state name} /> to display errors
+
+const validateForm = (requiredFields, stateGetter, errorSetter) => {
+    let submitErrors = {};
+    requiredFields.forEach(field => {
+      if (stateGetter[field].trim() === "") {
+        submitErrors = {
+          ...submitErrors,
+          [field]: "is required."
+        };
+      }
+    });
+    errorSetter(submitErrors);
+    return (
+      Object.entries(submitErrors).length === 0 &&
+      submitErrors.constructor === Object
+    );
+  };
+  
+  export default validateForm;
+  

--- a/views/layouts/default.hbs
+++ b/views/layouts/default.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Adopt a Pet!</title>
+    <title>Adopt a Magical Creature!</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/foundation/6.2.4/foundation.min.css">
     <link rel="stylesheet" href="/style.css">
   </head>


### PR DESCRIPTION
Add form to request adoption, includes front end validation. Includes reusable POJOs for posting data and form validation (this includes some comments on how to use it which we may need to reference to use for other forms, would like to keep this until all forms are completed if possible).

Right now, the component is not accessible since it is awaiting the completion of the creature show pages before it can be used. For testing, you may need to add in `<AdoptionFormButton>` somewhere. 